### PR TITLE
feat: args from env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,6 @@ dependencies = [
  "base64",
  "bnum",
  "chrono",
- "clap",
  "pretty_assertions",
  "redact",
  "reqwest",
@@ -214,9 +213,9 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.4"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "shlex",
 ]
@@ -1544,15 +1543,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -1791,12 +1789,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,9 +1920,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1945,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "base64",
  "bnum",
  "chrono",
+ "clap",
  "pretty_assertions",
  "redact",
  "reqwest",
@@ -1459,6 +1460,7 @@ name = "relayer-amplifier-api-integration"
 version = "0.1.1"
 dependencies = [
  "amplifier-api",
+ "clap",
  "common-serde-utils",
  "eyre",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,6 +1460,7 @@ name = "relayer-amplifier-api-integration"
 version = "0.1.1"
 dependencies = [
  "amplifier-api",
+ "base64",
  "clap",
  "common-serde-utils",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,7 @@ dependencies = [
 name = "relayer-engine"
 version = "0.1.1"
 dependencies = [
+ "clap",
  "eyre",
  "serde",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ amplifier-api = { path = "crates/amplifier-api" }
 common-serde-utils = { path = "crates/common-serde-utils" }
 
 # CLI
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 xshell = "0.2"
 
 # Utils

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ amplifier-api = { path = "crates/amplifier-api" }
 common-serde-utils = { path = "crates/common-serde-utils" }
 
 # CLI
-clap = { version = "4", features = ["derive", "env"] }
+clap = { version = "4", features = ["derive", "env", "string"] }
 xshell = "0.2"
 
 # Utils

--- a/crates/amplifier-api/Cargo.toml
+++ b/crates/amplifier-api/Cargo.toml
@@ -20,6 +20,7 @@ uuid.workspace = true
 chrono.workspace = true
 bnum.workspace = true
 typed-builder.workspace = true
+clap.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/amplifier-api/Cargo.toml
+++ b/crates/amplifier-api/Cargo.toml
@@ -20,7 +20,6 @@ uuid.workspace = true
 chrono.workspace = true
 bnum.workspace = true
 typed-builder.workspace = true
-clap.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/relayer-amplifier-api-integration/Cargo.toml
+++ b/crates/relayer-amplifier-api-integration/Cargo.toml
@@ -22,6 +22,7 @@ relayer-engine.workspace = true
 tokio-stream.workspace = true
 common-serde-utils.workspace = true
 relayer-amplifier-state.workspace = true
+clap.workspace = true
 
 [lints]
 workspace = true

--- a/crates/relayer-amplifier-api-integration/Cargo.toml
+++ b/crates/relayer-amplifier-api-integration/Cargo.toml
@@ -23,6 +23,7 @@ tokio-stream.workspace = true
 common-serde-utils.workspace = true
 relayer-amplifier-state.workspace = true
 clap.workspace = true
+base64.workspace = true
 
 [lints]
 workspace = true

--- a/crates/relayer-amplifier-api-integration/src/config.rs
+++ b/crates/relayer-amplifier-api-integration/src/config.rs
@@ -8,13 +8,13 @@ use typed_builder::TypedBuilder;
 #[derive(Debug, Deserialize, Clone, PartialEq, TypedBuilder, Parser)]
 pub struct Config {
     /// Identity certificate for the Amplifier API authentication to work
-    #[arg(env = "AMPLIFIER_API_IDENTITY", value_parser = parse_identity)]
+    #[arg(value_name = "AMPLIFIER_API_IDENTITY", env, value_parser = parse_identity)]
     pub identity: Identity,
     /// The Amplifier API url to connect to
-    #[arg(env = "AMPLIFIER_API_URL")]
+    #[arg(value_name = "AMPLIFIER_API_URL", env)]
     pub url: url::Url,
     /// The name of the chain that we need to send / listen for
-    #[arg(env = "AMPLIFIER_API_CHAIN")]
+    #[arg(value_name = "AMPLIFIER_API_CHAIN", env)]
     pub chain: String,
 
     /// The interval between polling Amplifier API for new tasks
@@ -25,7 +25,8 @@ pub struct Config {
         deserialize_with = "common_serde_utils::duration_ms_decode"
     )]
     #[arg(
-        env = "AMPLIFIER_API_CHAINS_POLL_INTERVAL", 
+        value_name = "AMPLIFIER_API_CHAINS_POLL_INTERVAL",
+        env,
         value_parser = parse_chains_poll_interval, 
         default_value = config_defaults::chains_poll_interval_default_value().to_string()
     )]
@@ -36,7 +37,8 @@ pub struct Config {
     #[builder(default = config_defaults::get_chains_limit())]
     #[serde(default = "config_defaults::get_chains_limit")]
     #[arg(
-        env = "AMPLIFIER_API_CHAINS_LIMIT", 
+        value_name = "AMPLIFIER_API_CHAINS_LIMIT",
+        env,
         default_value = config_defaults::get_chains_limit().to_string()
     )]
     pub get_chains_limit: u8,
@@ -49,7 +51,8 @@ pub struct Config {
         deserialize_with = "common_serde_utils::duration_ms_decode"
     )]
     #[arg(
-        env = "AMPLIFIER_API_HEALTHCHECK_INTERVAL", 
+        value_name = "AMPLIFIER_API_HEALTHCHECK_INTERVAL",
+        env,
         value_parser = parse_healthcheck_interval, 
         default_value = config_defaults::healthcheck_interval_default_value().to_string()
     )]
@@ -60,7 +63,8 @@ pub struct Config {
     #[builder(default = config_defaults::invalid_healthchecks_before_shutdown())]
     #[serde(default = "config_defaults::invalid_healthchecks_before_shutdown")]
     #[arg(
-        env = "AMPLIFIER_API_INVALID_HEALTHCHECKS_BEFORE_SHUTDOWN", 
+        value_name = "AMPLIFIER_API_INVALID_HEALTHCHECKS_BEFORE_SHUTDOWN",
+        env,
         default_value = config_defaults::invalid_healthchecks_before_shutdown().to_string()
     )]
     pub invalid_healthchecks_before_shutdown: usize,

--- a/crates/relayer-amplifier-api-integration/src/config.rs
+++ b/crates/relayer-amplifier-api-integration/src/config.rs
@@ -23,14 +23,21 @@ pub struct Config {
         default = "config_defaults::get_chains_poll_interval",
         deserialize_with = "common_serde_utils::duration_ms_decode"
     )]
-    #[arg(env = "AMPLIFIER_API_CHAINS_POLL_INTERVAL", value_parser = parse_chains_poll_interval)]
+    #[arg(
+        env = "AMPLIFIER_API_CHAINS_POLL_INTERVAL", 
+        value_parser = parse_chains_poll_interval, 
+        default_value = config_defaults::chains_poll_interval_default_value().to_string()
+    )]
     pub get_chains_poll_interval: core::time::Duration,
 
     /// The max amount of tasks that we want to receive in a batch.
     /// This goes hand-in-hand with the `get_chains_poll_interval`
     #[builder(default = config_defaults::get_chains_limit())]
     #[serde(default = "config_defaults::get_chains_limit")]
-    #[arg(env = "AMPLIFIER_API_CHAINS_LIMIT")]
+    #[arg(
+        env = "AMPLIFIER_API_CHAINS_LIMIT", 
+        default_value = config_defaults::get_chains_limit().to_string()
+    )]
     pub get_chains_limit: u8,
 
     /// How often we check the liveliness of the Amplifier API
@@ -40,15 +47,22 @@ pub struct Config {
         default = "config_defaults::healthcheck_interval",
         deserialize_with = "common_serde_utils::duration_ms_decode"
     )]
-    #[arg(env = "AMPLIFIER_API_HEALTHCHECK_INTERVAL", value_parser = parse_healthcheck_interval)]
+    #[arg(
+        env = "AMPLIFIER_API_HEALTHCHECK_INTERVAL", 
+        value_parser = parse_healthcheck_interval, 
+        default_value = config_defaults::healthcheck_interval_default_value().to_string()
+    )]
     pub healthcheck_interval: core::time::Duration,
 
     /// How many invalid healthchecks do we need to do before we deem that the service is down and
     /// we should shut down the component
     #[builder(default = config_defaults::invalid_healthchecks_before_shutdown())]
     #[serde(default = "config_defaults::invalid_healthchecks_before_shutdown")]
-    #[arg(env = "AMPLIFIER_API_INVALID_HEALTHCHECKS_BEFORE_SHUTDOWN")]
-    pub invalid_healthchecks_before_shutdown: Option<usize>,
+    #[arg(
+        env = "AMPLIFIER_API_INVALID_HEALTHCHECKS_BEFORE_SHUTDOWN", 
+        default_value = config_defaults::invalid_healthchecks_before_shutdown().to_string()
+    )]
+    pub invalid_healthchecks_before_shutdown: usize,
 }
 
 fn parse_identity(input: &str) -> Result<Identity, String> {
@@ -75,16 +89,24 @@ pub(crate) mod config_defaults {
     use core::time::Duration;
 
     pub(crate) const fn healthcheck_interval() -> Duration {
-        Duration::from_secs(10)
+        Duration::from_secs(healthcheck_interval_default_value())
+    }
+
+    pub(crate) const fn healthcheck_interval_default_value() -> u64 {
+        10
     }
 
     pub(crate) const fn get_chains_poll_interval() -> Duration {
-        Duration::from_secs(10)
+        Duration::from_secs(chains_poll_interval_default_value())
+    }
+
+    pub(crate) const fn chains_poll_interval_default_value() -> u64 {
+        10
     }
 
     #[expect(clippy::unnecessary_wraps, reason = "fine for config defaults")]
-    pub(crate) const fn invalid_healthchecks_before_shutdown() -> Option<usize> {
-        Some(5)
+    pub(crate) const fn invalid_healthchecks_before_shutdown() -> usize {
+        5
     }
     pub(crate) const fn get_chains_limit() -> u8 {
         4

--- a/crates/relayer-amplifier-api-integration/src/config.rs
+++ b/crates/relayer-amplifier-api-integration/src/config.rs
@@ -1,4 +1,5 @@
 use amplifier_api::identity::Identity;
+use base64::{prelude::BASE64_STANDARD, Engine};
 use clap::Parser;
 use eyre::Result;
 use serde::Deserialize;
@@ -71,7 +72,8 @@ pub struct Config {
 }
 
 fn parse_identity(input: &str) -> Result<Identity> {
-    Ok(Identity::new_from_pem_bytes(input.as_bytes())?)
+    let identity_bytes = BASE64_STANDARD.decode(input)?;
+    Ok(Identity::new_from_pem_bytes(&identity_bytes)?)
 }
 
 fn parse_chains_poll_interval(input: &str) -> Result<core::time::Duration> {

--- a/crates/relayer-amplifier-api-integration/src/config.rs
+++ b/crates/relayer-amplifier-api-integration/src/config.rs
@@ -60,7 +60,7 @@ pub struct Config {
         value_name = "AMPLIFIER_API_HEALTHCHECK_INTERVAL",
         env = "AMPLIFIER_API_HEALTHCHECK_INTERVAL", 
         value_parser = parse_healthcheck_interval,
-        default_value = "bla"
+        default_value = config_defaults::healthcheck_interval_default_value().to_string()
     )]
     pub healthcheck_interval: core::time::Duration,
 

--- a/crates/relayer-amplifier-api-integration/src/config.rs
+++ b/crates/relayer-amplifier-api-integration/src/config.rs
@@ -1,5 +1,6 @@
 use amplifier_api::identity::Identity;
 use clap::Parser;
+use eyre::Result;
 use serde::Deserialize;
 use typed_builder::TypedBuilder;
 
@@ -65,23 +66,21 @@ pub struct Config {
     pub invalid_healthchecks_before_shutdown: usize,
 }
 
-fn parse_identity(input: &str) -> Result<Identity, String> {
-    Ok(Identity::new_from_pem_bytes(input.as_bytes()).expect("failed to parse identity"))
+fn parse_identity(input: &str) -> Result<Identity> {
+    Ok(Identity::new_from_pem_bytes(input.as_bytes())?)
 }
 
-fn parse_chains_poll_interval(input: &str) -> Result<core::time::Duration, String> {
+fn parse_chains_poll_interval(input: &str) -> Result<core::time::Duration> {
     Ok(core::time::Duration::from_secs(
         input
-            .parse::<u64>()
-            .expect("failed to parse chains poll interval"),
+            .parse::<u64>()?,
     ))
 }
 
-fn parse_healthcheck_interval(input: &str) -> Result<core::time::Duration, String> {
+fn parse_healthcheck_interval(input: &str) -> Result<core::time::Duration> {
     Ok(core::time::Duration::from_secs(
         input
-            .parse::<u64>()
-            .expect("failed to parse healthcheck interval"),
+            .parse::<u64>()?
     ))
 }
 

--- a/crates/relayer-amplifier-api-integration/src/config.rs
+++ b/crates/relayer-amplifier-api-integration/src/config.rs
@@ -1,6 +1,6 @@
 use amplifier_api::identity::Identity;
 use base64::prelude::BASE64_STANDARD;
-use base64::Engine;
+use base64::Engine as _;
 use clap::Parser;
 use eyre::Result;
 use serde::Deserialize;
@@ -108,7 +108,6 @@ pub(crate) mod config_defaults {
         10
     }
 
-    #[expect(clippy::unnecessary_wraps, reason = "fine for config defaults")]
     pub(crate) const fn invalid_healthchecks_before_shutdown() -> usize {
         5
     }

--- a/crates/relayer-amplifier-api-integration/src/config.rs
+++ b/crates/relayer-amplifier-api-integration/src/config.rs
@@ -1,5 +1,6 @@
 use amplifier_api::identity::Identity;
-use base64::{prelude::BASE64_STANDARD, Engine};
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
 use clap::Parser;
 use eyre::Result;
 use serde::Deserialize;
@@ -9,13 +10,17 @@ use typed_builder::TypedBuilder;
 #[derive(Debug, Deserialize, Clone, PartialEq, TypedBuilder, Parser)]
 pub struct Config {
     /// Identity certificate for the Amplifier API authentication to work
-    #[arg(value_name = "AMPLIFIER_API_IDENTITY", env, value_parser = parse_identity)]
+    #[arg(
+        value_name = "AMPLIFIER_API_IDENTITY",
+        env = "AMPLIFIER_API_IDENTITY",
+        value_parser = parse_identity
+    )]
     pub identity: Identity,
     /// The Amplifier API url to connect to
-    #[arg(value_name = "AMPLIFIER_API_URL", env)]
+    #[arg(value_name = "AMPLIFIER_API_URL", env = "AMPLIFIER_API_URL")]
     pub url: url::Url,
     /// The name of the chain that we need to send / listen for
-    #[arg(value_name = "AMPLIFIER_API_CHAIN", env)]
+    #[arg(value_name = "AMPLIFIER_API_CHAIN", env = "AMPLIFIER_API_CHAIN")]
     pub chain: String,
 
     /// The interval between polling Amplifier API for new tasks
@@ -27,8 +32,8 @@ pub struct Config {
     )]
     #[arg(
         value_name = "AMPLIFIER_API_CHAINS_POLL_INTERVAL",
-        env,
-        value_parser = parse_chains_poll_interval, 
+        env = "AMPLIFIER_API_CHAINS_POLL_INTERVAL", 
+        value_parser = parse_chains_poll_interval,
         default_value = config_defaults::chains_poll_interval_default_value().to_string()
     )]
     pub get_chains_poll_interval: core::time::Duration,
@@ -39,7 +44,7 @@ pub struct Config {
     #[serde(default = "config_defaults::get_chains_limit")]
     #[arg(
         value_name = "AMPLIFIER_API_CHAINS_LIMIT",
-        env,
+        env = "AMPLIFIER_API_CHAINS_LIMIT", 
         default_value = config_defaults::get_chains_limit().to_string()
     )]
     pub get_chains_limit: u8,
@@ -53,9 +58,9 @@ pub struct Config {
     )]
     #[arg(
         value_name = "AMPLIFIER_API_HEALTHCHECK_INTERVAL",
-        env,
-        value_parser = parse_healthcheck_interval, 
-        default_value = config_defaults::healthcheck_interval_default_value().to_string()
+        env = "AMPLIFIER_API_HEALTHCHECK_INTERVAL", 
+        value_parser = parse_healthcheck_interval,
+        default_value = "bla"
     )]
     pub healthcheck_interval: core::time::Duration,
 
@@ -65,7 +70,7 @@ pub struct Config {
     #[serde(default = "config_defaults::invalid_healthchecks_before_shutdown")]
     #[arg(
         value_name = "AMPLIFIER_API_INVALID_HEALTHCHECKS_BEFORE_SHUTDOWN",
-        env,
+        env = "AMPLIFIER_API_INVALID_HEALTHCHECKS_BEFORE_SHUTDOWN", 
         default_value = config_defaults::invalid_healthchecks_before_shutdown().to_string()
     )]
     pub invalid_healthchecks_before_shutdown: usize,
@@ -77,17 +82,11 @@ fn parse_identity(input: &str) -> Result<Identity> {
 }
 
 fn parse_chains_poll_interval(input: &str) -> Result<core::time::Duration> {
-    Ok(core::time::Duration::from_secs(
-        input
-            .parse::<u64>()?,
-    ))
+    Ok(core::time::Duration::from_secs(input.parse::<u64>()?))
 }
 
 fn parse_healthcheck_interval(input: &str) -> Result<core::time::Duration> {
-    Ok(core::time::Duration::from_secs(
-        input
-            .parse::<u64>()?
-    ))
+    Ok(core::time::Duration::from_secs(input.parse::<u64>()?))
 }
 
 pub(crate) mod config_defaults {

--- a/crates/relayer-amplifier-api-integration/src/config.rs
+++ b/crates/relayer-amplifier-api-integration/src/config.rs
@@ -1,15 +1,19 @@
 use amplifier_api::identity::Identity;
+use clap::Parser;
 use serde::Deserialize;
 use typed_builder::TypedBuilder;
 
 /// global Amplifier component configuration
-#[derive(Debug, Deserialize, Clone, PartialEq, TypedBuilder)]
+#[derive(Debug, Deserialize, Clone, PartialEq, TypedBuilder, Parser)]
 pub struct Config {
     /// Identity certificate for the Amplifier API authentication to work
+    #[arg(env = "AMPLIFIER_API_IDENTITY", value_parser = parse_identity)]
     pub identity: Identity,
     /// The Amplifier API url to connect to
+    #[arg(env = "AMPLIFIER_API_URL")]
     pub url: url::Url,
     /// The name of the chain that we need to send / listen for
+    #[arg(env = "AMPLIFIER_API_CHAIN")]
     pub chain: String,
 
     /// The interval between polling Amplifier API for new tasks
@@ -19,12 +23,14 @@ pub struct Config {
         default = "config_defaults::get_chains_poll_interval",
         deserialize_with = "common_serde_utils::duration_ms_decode"
     )]
+    #[arg(env = "AMPLIFIER_API_CHAINS_POLL_INTERVAL", value_parser = parse_chains_poll_interval)]
     pub get_chains_poll_interval: core::time::Duration,
 
     /// The max amount of tasks that we want to receive in a batch.
     /// This goes hand-in-hand with the `get_chains_poll_interval`
     #[builder(default = config_defaults::get_chains_limit())]
     #[serde(default = "config_defaults::get_chains_limit")]
+    #[arg(env = "AMPLIFIER_API_CHAINS_LIMIT")]
     pub get_chains_limit: u8,
 
     /// How often we check the liveliness of the Amplifier API
@@ -34,13 +40,35 @@ pub struct Config {
         default = "config_defaults::healthcheck_interval",
         deserialize_with = "common_serde_utils::duration_ms_decode"
     )]
+    #[arg(env = "AMPLIFIER_API_HEALTHCHECK_INTERVAL", value_parser = parse_healthcheck_interval)]
     pub healthcheck_interval: core::time::Duration,
 
     /// How many invalid healthchecks do we need to do before we deem that the service is down and
     /// we should shut down the component
     #[builder(default = config_defaults::invalid_healthchecks_before_shutdown())]
     #[serde(default = "config_defaults::invalid_healthchecks_before_shutdown")]
+    #[arg(env = "AMPLIFIER_API_INVALID_HEALTHCHECKS_BEFORE_SHUTDOWN")]
     pub invalid_healthchecks_before_shutdown: Option<usize>,
+}
+
+fn parse_identity(input: &str) -> Result<Identity, String> {
+    Ok(Identity::new_from_pem_bytes(input.as_bytes()).expect("failed to parse identity"))
+}
+
+fn parse_chains_poll_interval(input: &str) -> Result<core::time::Duration, String> {
+    Ok(core::time::Duration::from_secs(
+        input
+            .parse::<u64>()
+            .expect("failed to parse chains poll interval"),
+    ))
+}
+
+fn parse_healthcheck_interval(input: &str) -> Result<core::time::Duration, String> {
+    Ok(core::time::Duration::from_secs(
+        input
+            .parse::<u64>()
+            .expect("failed to parse healthcheck interval"),
+    ))
 }
 
 pub(crate) mod config_defaults {

--- a/crates/relayer-amplifier-api-integration/src/healthcheck.rs
+++ b/crates/relayer-amplifier-api-integration/src/healthcheck.rs
@@ -21,11 +21,7 @@ pub(crate) async fn process_healthcheck(
         tracing::info!(execution_duration = ?delta, "healthcheck duration");
 
         // check if amplifier api is unreachable for a long time already
-        let Some(invalid_healthchecks_before_shutdown) =
-            config.invalid_healthchecks_before_shutdown
-        else {
-            continue
-        };
+        let invalid_healthchecks_before_shutdown = config.invalid_healthchecks_before_shutdown;
 
         if healthceck_succeeded {
             healthcheck_current_failures = 0;

--- a/crates/relayer-engine/Cargo.toml
+++ b/crates/relayer-engine/Cargo.toml
@@ -13,6 +13,7 @@ url.workspace = true
 eyre.workspace = true
 tracing.workspace = true
 tokio.workspace = true
+clap.workspace = true
 
 [lints]
 workspace = true

--- a/crates/relayer-engine/src/config.rs
+++ b/crates/relayer-engine/src/config.rs
@@ -30,13 +30,17 @@ pub trait RelayerComponent {
 #[derive(Debug, Deserialize, PartialEq, Eq, Parser)]
 pub struct Config {
     /// Health check server configuration.
-    #[arg(value_name = "RELAYER_ENGINE_HEALTH_CHECK", env, value_parser = parse_health_check)]
+    #[arg(
+        value_name = "RELAYER_ENGINE_HEALTH_CHECK", 
+        env = "RELAYER_ENGINE_HEALTH_CHECK", 
+        value_parser = parse_health_check
+    )]
     pub health_check: HealthCheckConfig,
 }
 
 fn parse_health_check(input: &str) -> Result<HealthCheckConfig> {
     Ok(HealthCheckConfig {
-        bind_addr: SocketAddr::from_str(input)?
+        bind_addr: SocketAddr::from_str(input)?,
     })
 }
 

--- a/crates/relayer-engine/src/config.rs
+++ b/crates/relayer-engine/src/config.rs
@@ -3,7 +3,7 @@
 use core::future::Future;
 use core::net::SocketAddr;
 use core::pin::Pin;
-use std::str::FromStr;
+use core::str::FromStr as _;
 
 use clap::Parser;
 use eyre::Result;

--- a/crates/relayer-engine/src/config.rs
+++ b/crates/relayer-engine/src/config.rs
@@ -30,7 +30,7 @@ pub trait RelayerComponent {
 #[derive(Debug, Deserialize, PartialEq, Eq, Parser)]
 pub struct Config {
     /// Health check server configuration.
-    #[arg(env = "RELAYER_ENGINE_HEALTH_CHECK", value_parser = parse_health_check)]
+    #[arg(value_name = "RELAYER_ENGINE_HEALTH_CHECK", env, value_parser = parse_health_check)]
     pub health_check: HealthCheckConfig,
 }
 

--- a/crates/relayer-engine/src/config.rs
+++ b/crates/relayer-engine/src/config.rs
@@ -6,6 +6,7 @@ use core::pin::Pin;
 use std::str::FromStr;
 
 use clap::Parser;
+use eyre::Result;
 use serde::Deserialize;
 
 /// Generic async component that the Relyer Engine can spawn and execute.
@@ -21,7 +22,7 @@ pub trait RelayerComponent {
     ///   engine / other processes
     /// - `Err(eyre::Report)` -- the component is shutting down with a fatal error and it requires
     ///   the shutdown of the whole engine
-    fn process(self: Box<Self>) -> Pin<Box<dyn Future<Output = eyre::Result<()>> + Send>>;
+    fn process(self: Box<Self>) -> Pin<Box<dyn Future<Output = Result<()>> + Send>>;
 }
 
 /// Top-level configuration for the relayer engine.
@@ -33,9 +34,9 @@ pub struct Config {
     pub health_check: HealthCheckConfig,
 }
 
-fn parse_health_check(input: &str) -> Result<HealthCheckConfig, String> {
+fn parse_health_check(input: &str) -> Result<HealthCheckConfig> {
     Ok(HealthCheckConfig {
-        bind_addr: SocketAddr::from_str(input).expect("failed to get health check"),
+        bind_addr: SocketAddr::from_str(input)?
     })
 }
 

--- a/crates/relayer-engine/src/config.rs
+++ b/crates/relayer-engine/src/config.rs
@@ -3,7 +3,9 @@
 use core::future::Future;
 use core::net::SocketAddr;
 use core::pin::Pin;
+use std::str::FromStr;
 
+use clap::Parser;
 use serde::Deserialize;
 
 /// Generic async component that the Relyer Engine can spawn and execute.
@@ -24,14 +26,21 @@ pub trait RelayerComponent {
 
 /// Top-level configuration for the relayer engine.
 /// Agnostic to the underlying components.
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Parser)]
 pub struct Config {
     /// Health check server configuration.
+    #[arg(env = "RELAYER_ENGINE_HEALTH_CHECK", value_parser = parse_health_check)]
     pub health_check: HealthCheckConfig,
 }
 
+fn parse_health_check(input: &str) -> Result<HealthCheckConfig, String> {
+    Ok(HealthCheckConfig {
+        bind_addr: SocketAddr::from_str(input).expect("failed to get health check"),
+    })
+}
+
 /// Health check server configuration.
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Clone)]
 pub struct HealthCheckConfig {
     /// Address to bind the health check server.
     pub bind_addr: SocketAddr,

--- a/deny.toml
+++ b/deny.toml
@@ -72,7 +72,6 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    { id = "RUSTSEC-2024-0370", reason = "porc-macro-error: not an issue: unmaintanined but very popular" },
     { id = "RUSTSEC-2024-0384", reason = "states that 'No safe upgrade is available!'" },
     # "a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     # { crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> eyre::Result<()> {
     match args.command {
         Commands::Deny { args } => {
             println!("cargo deny");
-            cmd!(sh, "cargo install cargo-deny").run()?;
+            cmd!(sh, "cargo install --version 0.17.0 cargo-deny").run()?;
             cmd!(sh, "cargo deny check {args...}").run()?;
         }
         Commands::Test { args, coverage } => {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -105,7 +105,7 @@ fn main() -> eyre::Result<()> {
         }
         Commands::UnusedDeps => {
             println!("unused deps");
-            cmd!(sh, "cargo install cargo-machete").run()?;
+            cmd!(sh, "cargo install --version 0.7.0 cargo-machete").run()?;
             cmd!(sh, "cargo-machete").run()?;
         }
     }


### PR DESCRIPTION
**Describe the changes**
Due to the necessary reading of input arguments from environment in `relayer`, necessary changes in `configs` are necessary. 

**Checklist**

- [ ] Tests have been added/updated for the changes.
- [ ] Documentation has been updated for the changes (if applicable).
- [ ] The code follows Rust's style guidelines.

**Additional Context**

- `value_parser = custom_function` - necessary for specific types like `core::Time::Duration` due to parsing error with `#[arg(env = NAME)]`; only `&str` is possible as input which results in numbered types to be input from environment as `"10"`
- `invalid_healthchecks_before_shutdown` - removed `Option`, unnecessary due to default value, if `None` just set 0
- Didn't remove `serde` - maybe it is still used somewhere
