### PR TITLE
feat: implement standalone binaries with health monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ target/
 *.key
 config.toml
 store
+
+relayer-config.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,12 +66,20 @@ dependencies = [
 name = "amplifier-ingester"
 version = "0.1.1"
 dependencies = [
+ "bin-util",
+ "clap",
+ "ctrlc",
  "eyre",
  "futures",
  "infrastructure",
  "relayer-amplifier-api-integration",
+ "serde",
  "supervisor",
+ "tokio",
+ "tokio-util",
+ "toml",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -79,10 +87,19 @@ name = "amplifier-subscriber"
 version = "0.1.1"
 dependencies = [
  "amplifier-api",
+ "bin-util",
+ "clap",
+ "ctrlc",
  "eyre",
  "infrastructure",
+ "relayer-amplifier-api-integration",
+ "serde",
  "supervisor",
+ "tokio",
+ "tokio-util",
+ "toml",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -275,10 +292,13 @@ checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
 dependencies = [
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -287,10 +307,15 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -310,6 +335,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -358,8 +384,15 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 name = "bin-util"
 version = "0.1.1"
 dependencies = [
+ "axum",
  "ctrlc",
+ "eyre",
+ "futures",
+ "reqwest",
+ "serde_json",
+ "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2701,6 +2734,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,6 +2752,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3166,10 +3218,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3178,9 +3245,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tonic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,6 +197,9 @@ opentelemetry-semantic-conventions = "0.25"
 opentelemetry_sdk = { version = "0.25", features = ["rt-tokio"] }
 opentelemetry-appender-tracing = { version = "0.25" }
 
+# health-check server
+axum = "0.8"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Axelar Relayer core libraries
+
 This repo provides building blocks for Axelar<>Blockchain Relayer
 
 ## Relayer Architecture Overview
+
 ```mermaid
 graph TD
     subgraph "Relayer System"
@@ -60,11 +62,13 @@ graph TD
 The relayer establishes bidirectional communication between an Amplifier API and a blockchain. It consists of these main flows:
 
 ### Amplifier to Blockchain Flow
+
 - **Amplifier Subscriber**: Subscribes to the Amplifier REST API and receives amplifier tasks then sends them to queue
 - **Amplifier Tasks Queue**: Stores amplifier tasks
 - **Blockchain Ingester**: Consumes tasks from the queue, transforms them to a compatible format, and includes them in the blockchain
 
 ### Blockchain to Amplifier Flow
+
 - **Blockchain Subscriber**: Subscribes to blockchain events, transforms them into amplifier events and sends to queue
 - **Amplifier Events Queue**: Stores amplifier events
 - **Amplifier Ingester**: Consumes events from the queue and sends them to the Amplifier API
@@ -74,6 +78,7 @@ The relayer establishes bidirectional communication between an Amplifier API and
 The relayer is designed as 4 components: 2 ingestors & 2 subscribers - 1 for each chain (Axelar/amplifier API and the connecting chain)
 
 1. **Supervisor**(optional):
+
    - Runs on its own dedicated thread with a Tokio runtime
    - Spawns and monitors worker threads only for the components selected via CLI
    - Detects crashes and automatically restarts failed components
@@ -81,6 +86,7 @@ The relayer is designed as 4 components: 2 ingestors & 2 subscribers - 1 for eac
    - Is fully optional
 
 2. **Termination Handling**:
+
    - A dedicated thread listens for Ctrl+C signals
    - Uses an CancellationToken as a shared termination flag
    - When Ctrl+C is received, the CancellationToken is set to true
@@ -88,6 +94,7 @@ The relayer is designed as 4 components: 2 ingestors & 2 subscribers - 1 for eac
    - Upon termination, components have graceful period to finish current work
 
 3. **Worker Components**:
+
    - Each component (Amplifier Subscriber, Blockchain Ingester, Blockchain Subscriber, Amplifier Ingester) runs isolated
    - Components check the termination flag regularly and shut down when needed
    - Isolation ensures a failure in one component doesn't affect others
@@ -101,3 +108,68 @@ The relayer is designed as 4 components: 2 ingestors & 2 subscribers - 1 for eac
    - Supports horizontal scaling by allowing multiple instances to consume from the same queue
 
 The supervisor is optional, and each component can be started as a separate binary.RetryClaude can make mistakes. Please double-check responses.
+
+## Running the Components
+
+### Configuration
+
+Before running the components, you need to create a configuration file. An example configuration file is provided in `relayer-config-example.toml`. You can copy this file and modify it according to your needs:
+
+```bash
+cp relayer-config-example.toml relayer-config.toml
+```
+
+Edit the `relayer-config.toml` file to configure:
+
+- Amplifier API configuration
+- Backend configuration (NATS or GCP Pub/Sub)
+- Tickrate for processing events
+- Health check endpoints
+
+### Running Amplifier Ingester
+
+```bash
+# Build the ingester
+cargo build --bin amplifier-ingester
+
+# Run with default config path (looks for relayer-config.toml in current directory)
+./target/debug/amplifier-ingester
+
+# Or specify a custom config path
+./target/debug/amplifier-ingester --config /path/to/your/config.toml
+```
+
+### Running Amplifier Subscriber
+
+```bash
+# Build the subscriber
+cargo build --bin amplifier-subscriber
+
+# Run with default config path (looks for relayer-config.toml in current directory)
+./target/debug/amplifier-subscriber
+
+# Or specify a custom config path
+./target/debug/amplifier-subscriber --config /path/to/your/config.toml
+```
+
+### Running with Specific Backend
+
+By default, both components are built with NATS support. To use GCP as the backend, compile with the `gcp` feature:
+
+```bash
+# Build with GCP backend support
+cargo build --bin amplifier-ingester --features gcp --no-default-features
+cargo build --bin amplifier-subscriber --features gcp --no-default-features
+```
+
+### Health Checks
+
+Once running, you can check the health of the components by sending an HTTP request to the configured health check endpoints:
+
+```bash
+# Check health of a component (assuming default port 8080)
+curl http://localhost:8080/healthz
+
+# Check readiness of a component
+curl http://localhost:8080/readyz
+```

--- a/README.md
+++ b/README.md
@@ -154,12 +154,12 @@ cargo build --bin amplifier-subscriber
 
 ### Running with Specific Backend
 
-By default, both components are built with NATS support. To use GCP as the backend, compile with the `gcp` feature:
+By default, both components are built with GCP support. To use NATS as the backend, compile with the `nats` feature:
 
 ```bash
-# Build with GCP backend support
-cargo build --bin amplifier-ingester --features gcp --no-default-features
-cargo build --bin amplifier-subscriber --features gcp --no-default-features
+# Build with nats backend support
+cargo build --bin amplifier-ingester --features nats --no-default-features
+cargo build --bin amplifier-subscriber --features nats --no-default-features
 ```
 
 ### Health Checks

--- a/crates/amplifier-ingester/Cargo.toml
+++ b/crates/amplifier-ingester/Cargo.toml
@@ -13,7 +13,33 @@ supervisor.workspace = true
 tracing.workspace = true
 eyre.workspace = true
 infrastructure = { workspace = true, features = ["consumer-interfaces"] }
+tokio.workspace = true
+tokio-util.workspace = true
+serde.workspace = true
+clap.workspace = true
+ctrlc.workspace = true
+toml.workspace = true
+url.workspace = true
+bin-util.workspace = true
+
+
 futures.workspace = true
+
+[features]
+default = ["gcp"]
+nats = [
+  "consumer-interfaces",
+  "publisher-interfaces",
+  "storage-interfaces",
+]
+gcp = [
+  "consumer-interfaces",
+  "publisher-interfaces",
+  "storage-interfaces",
+]
+consumer-interfaces = []
+publisher-interfaces = []
+storage-interfaces = []
 
 [lints]
 workspace = true

--- a/crates/amplifier-ingester/src/components.rs
+++ b/crates/amplifier-ingester/src/components.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "gcp")]
+pub(crate) mod gcp;
+#[cfg(feature = "nats")]
+pub(crate) mod nats;

--- a/crates/amplifier-ingester/src/components/gcp.rs
+++ b/crates/amplifier-ingester/src/components/gcp.rs
@@ -1,0 +1,98 @@
+use std::path::PathBuf;
+
+use eyre::{Context as _, ensure, eyre};
+use infrastructure::gcp;
+use infrastructure::gcp::consumer::GcpConsumer;
+use relayer_amplifier_api_integration::amplifier_api::{self, AmplifierApiClient};
+use serde::Deserialize;
+use tokio_util::sync::CancellationToken;
+
+use crate::config::{self, Config, Validate};
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub(crate) struct GcpSectionConfig {
+    pub gcp: GcpConfig,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub(crate) struct GcpConfig {
+    redis_connection: String,
+
+    tasks_topic: String,
+    tasks_subscription: String,
+
+    events_topic: String,
+    events_subscription: String,
+
+    nak_deadline_secs: i32,
+
+    message_buffer_size: usize,
+}
+
+impl Validate for GcpSectionConfig {
+    fn validate(&self) -> eyre::Result<()> {
+        ensure!(
+            !self.gcp.redis_connection.is_empty(),
+            eyre!("gcp redis_connection should be set")
+        );
+        ensure!(
+            !self.gcp.tasks_topic.is_empty(),
+            eyre!("gcp tasks_topic should be set")
+        );
+        ensure!(
+            !self.gcp.tasks_subscription.is_empty(),
+            eyre!("gcp tasks_subscription should be set")
+        );
+        ensure!(
+            !self.gcp.events_topic.is_empty(),
+            eyre!("gcp events_topic should be set")
+        );
+        ensure!(
+            !self.gcp.events_subscription.is_empty(),
+            eyre!("gcp events_subscription should be set")
+        );
+        ensure!(
+            self.gcp.nak_deadline_secs > 0_i32,
+            eyre!("gcp nak_deadline_secs should be positive set")
+        );
+        ensure!(
+            self.gcp.message_buffer_size > 0,
+            eyre!("gcp message_buffer_size should be set")
+        );
+        Ok(())
+    }
+}
+
+pub(crate) async fn new_amplifier_ingester(
+    config_path: PathBuf,
+    cancellation_token: CancellationToken,
+) -> eyre::Result<amplifier_ingester::Ingester<GcpConsumer<amplifier_api::types::Event>>> {
+    let config = config::try_deserialize(&config_path).wrap_err("config file issues")?;
+    let queue_config: GcpSectionConfig =
+        config::try_deserialize(&config_path).wrap_err("gcp pubsub config issues")?;
+    let amplifier_client = amplifier_client(&config)?;
+
+    let event_queue_consumer = gcp::connectors::connect_consumer(
+        &queue_config.gcp.events_subscription,
+        queue_config.gcp.message_buffer_size,
+        queue_config.gcp.nak_deadline_secs,
+        cancellation_token,
+    )
+    .await
+    .wrap_err("event consumer connect err")?;
+
+    Ok(amplifier_ingester::Ingester::new(
+        amplifier_client,
+        event_queue_consumer,
+        config.amplifier_component.chain.clone(),
+        config.concurrent_queue_items,
+    ))
+}
+
+fn amplifier_client(config: &Config) -> eyre::Result<AmplifierApiClient> {
+    AmplifierApiClient::new(
+        config.amplifier_component.url.clone(),
+        amplifier_api::TlsType::Certificate(Box::new(config.amplifier_component.identity.clone())),
+    )
+    .wrap_err("amplifier api client failed to create")
+}

--- a/crates/amplifier-ingester/src/components/nats.rs
+++ b/crates/amplifier-ingester/src/components/nats.rs
@@ -1,0 +1,82 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use eyre::{Context, ensure, eyre};
+use infrastructure::nats::consumer::NatsConsumer;
+use infrastructure::nats::{self, StreamArgs};
+use relayer_amplifier_api_integration::amplifier_api::{self, AmplifierApiClient};
+use serde::Deserialize;
+use url::Url;
+
+use crate::Config;
+use crate::config::{self, Validate, deserialize_duration_from_secs};
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub(crate) struct NatsSectionConfig {
+    pub nats: NatsConfig,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub(crate) struct NatsConfig {
+    pub urls: Vec<Url>,
+    #[serde(rename = "connection_timeout_secs")]
+    #[serde(deserialize_with = "deserialize_duration_from_secs")]
+    pub connection_timeout: Duration,
+
+    pub stream_name: String,
+    pub stream_subject: String,
+    pub stream_description: String,
+
+    pub consumer_description: String,
+    pub deliver_group: String,
+}
+
+impl Validate for NatsSectionConfig {
+    fn validate(&self) -> eyre::Result<()> {
+        ensure!(
+            !self.nats.urls.is_empty(),
+            eyre!("nats urls should have at least one connection")
+        );
+
+        Ok(())
+    }
+}
+
+pub(crate) async fn new_amplifier_ingester(
+    config_path: PathBuf,
+) -> eyre::Result<amplifier_ingester::Ingester<NatsConsumer<amplifier_api::types::Event>>> {
+    let config = config::try_deserialize(&config_path).wrap_err("config file issues")?;
+    let nats_config: NatsSectionConfig =
+        config::try_deserialize(&config_path).wrap_err("nats config issues")?;
+    let amplifier_client = amplifier_client(&config)?;
+
+    let stream = StreamArgs {
+        name: nats_config.nats.stream_name.to_owned(),
+        subject: nats_config.nats.stream_subject.to_owned(),
+        description: nats_config.nats.stream_description.to_owned(),
+    };
+
+    let event_queue_consumer = nats::connectors::connect_consumer(
+        &nats_config.nats.urls,
+        stream,
+        nats_config.nats.consumer_description,
+        nats_config.nats.deliver_group,
+    )
+    .await
+    .wrap_err("event consumer connect err")?;
+
+    Ok(amplifier_ingester::Ingester::new(
+        amplifier_client,
+        event_queue_consumer,
+        config.amplifier_component.chain.clone(),
+        config.concurrent_queue_items,
+    ))
+}
+
+fn amplifier_client(config: &Config) -> eyre::Result<AmplifierApiClient> {
+    AmplifierApiClient::new(
+        config.amplifier_component.url.clone(),
+        amplifier_api::TlsType::Certificate(Box::new(config.amplifier_component.identity.clone())),
+    )
+    .wrap_err("amplifier api client failed to create")
+}

--- a/crates/amplifier-ingester/src/config.rs
+++ b/crates/amplifier-ingester/src/config.rs
@@ -1,0 +1,69 @@
+use core::time::Duration;
+use std::path::Path;
+
+use eyre::{WrapErr as _, ensure, eyre};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Deserializer};
+
+pub(crate) trait Validate {
+    fn validate(&self) -> eyre::Result<()>;
+}
+
+/// Top-level configuration for the relayer.
+#[derive(Debug, Deserialize, PartialEq)]
+pub(crate) struct Config {
+    /// Configuration for the Amplifier API processor
+    pub amplifier_component: relayer_amplifier_api_integration::Config,
+
+    pub concurrent_queue_items: usize,
+    /// Duration (in seconds) to wait between consecutive polling
+    /// operations Used to prevent overwhelming the network with requests
+    #[serde(rename = "tickrate_secs")]
+    #[serde(deserialize_with = "deserialize_duration_from_secs")]
+    pub tickrate: Duration,
+
+    /// Configuration for health check server
+    #[serde(rename = "health_check_server")]
+    pub health_check: HealthCheckConfig,
+}
+
+/// Configuration for health check server
+#[derive(Debug, Deserialize, PartialEq)]
+pub(crate) struct HealthCheckConfig {
+    /// Port for the health check server
+    #[serde(rename = "port")]
+    pub port: u16,
+}
+
+impl Validate for Config {
+    fn validate(&self) -> eyre::Result<()> {
+        ensure!(
+            !self.amplifier_component.chain.trim().is_empty(),
+            "chain could not be empty",
+        );
+
+        Ok(())
+    }
+}
+
+pub(crate) fn try_deserialize<T: DeserializeOwned + Validate>(
+    config_path: &Path,
+) -> eyre::Result<T> {
+    ensure!(
+        config_path.exists() && config_path.is_file(),
+        eyre!("Path should be a file and exist {:?}", config_path)
+    );
+    let config_file = std::fs::read_to_string(config_path).wrap_err("cannot read config file")?;
+
+    let config = toml::from_str::<T>(&config_file).wrap_err("invalid config file content")?;
+    config.validate()?;
+    Ok(config)
+}
+
+pub(crate) fn deserialize_duration_from_secs<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let seconds = u64::deserialize(deserializer)?;
+    Ok(Duration::from_secs(seconds))
+}

--- a/crates/amplifier-ingester/src/main.rs
+++ b/crates/amplifier-ingester/src/main.rs
@@ -37,7 +37,7 @@ use config::Config;
 use tokio_util::sync::CancellationToken;
 
 // TODO: Move this to config
-const MAX_ERRORS: i32 = 5;
+const MAX_ERRORS: i32 = 20;
 #[derive(Parser, Debug)]
 #[command(author = "Eiger", name = "Axelar<>Blockchain Relayer")]
 pub(crate) struct Cli {

--- a/crates/amplifier-ingester/src/main.rs
+++ b/crates/amplifier-ingester/src/main.rs
@@ -1,0 +1,179 @@
+//! # Amplifier Ingester
+//!
+//! The Amplifier Ingester service connects to the Axelar Amplifier network
+//! and periodically ingests events from the network that need to be relayed.
+//!
+//! This binary provides:
+//! - A configurable event ingestion service with different backend implementations (NATS, GCP)
+//! - Health check endpoints for monitoring service health
+//! - Graceful shutdown handling with signal trapping
+//!
+//! The service will periodically check for new events based on the configured tickrate
+//! and process them according to the configured backend (NATS or GCP).
+//!
+//! ## Usage
+//!
+//! ```bash
+//! amplifier-ingester --config path/to/config.toml
+//! ```
+//!
+//! ## Configuration
+//!
+//! The service is configured via a TOML file that specifies:
+//! - Health check server port
+//! - Event processing tickrate
+//! - Backend-specific configuration (NATS or GCP)
+//!
+mod components;
+mod config;
+
+use core::time::Duration;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use bin_util::health_check;
+use clap::Parser;
+use config::Config;
+use tokio_util::sync::CancellationToken;
+
+// TODO: Move this to config
+const MAX_ERRORS: i32 = 5;
+#[derive(Parser, Debug)]
+#[command(author = "Eiger", name = "Axelar<>Blockchain Relayer")]
+pub(crate) struct Cli {
+    #[arg(
+        long,
+        short,
+        default_value = "relayer-config.toml",
+        help = "Config path"
+    )]
+    pub config_path: PathBuf,
+}
+
+#[tokio::main]
+async fn main() {
+    #[cfg(debug_assertions)]
+    {
+        // Safety: Setting an environment variable is safe in this context because it only affects the current process.
+        unsafe {
+            std::env::set_var("RUST_BACKTRACE", "full");
+        }
+    }
+
+    let cli = Cli::parse();
+
+    let config: Config = config::try_deserialize(&cli.config_path).expect("generic config");
+    let cancel_token = setup_shutdown_signal();
+
+    tokio::try_join!(
+        spawn_subscriber_worker(
+            config.tickrate,
+            cli.config_path.clone(),
+            cancel_token.clone()
+        ),
+        spawn_health_check_server(
+            config.health_check.port,
+            cli.config_path.clone(),
+            cancel_token.clone()
+        )
+    )
+    .expect("Failed to join tasks");
+
+    tracing::info!("Amplifier ingester has been shut down");
+}
+
+fn setup_shutdown_signal() -> CancellationToken {
+    let token = CancellationToken::new();
+    let token_clone = token.clone();
+
+    ctrlc::set_handler(move || {
+        if token_clone.is_cancelled() {
+            tracing::warn!("Immediate shutdown initiated.");
+            #[expect(clippy::restriction, reason = "immediate exit")]
+            std::process::exit(1);
+        } else {
+            tracing::info!("Graceful shutdown initiated. Press Ctrl+C again for immediate exit.");
+            token_clone.cancel();
+        }
+    })
+    .expect("Failed to register ctrl+c handler");
+
+    token
+}
+
+fn spawn_subscriber_worker(
+    tickrate: Duration,
+    config_path: PathBuf,
+    cancel_token: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    // Avoid shadowing by renaming the variable
+    let shutdown_token = cancel_token;
+    tokio::task::spawn(async move {
+        #[cfg(feature = "nats")]
+        let ingester = components::nats::new_amplifier_ingester(config_path)
+            .await
+            .expect("ingester is created");
+
+        #[cfg(feature = "gcp")]
+        let ingester = components::gcp::new_amplifier_ingester(config_path, shutdown_token.clone())
+            .await
+            .expect("ingester is created");
+
+        tracing::debug!("Starting amplifier ingester...");
+
+        shutdown_token
+            .run_until_cancelled(async move {
+                let mut work_interval = tokio::time::interval(tickrate);
+                let mut error_count: i32 = 0;
+
+                loop {
+                    work_interval.tick().await;
+                    if let Err(err) = ingester.ingest().await {
+                        tracing::error!(?err, "error during ingest, skipping...");
+                        error_count = error_count.saturating_add(1);
+                        if error_count >= MAX_ERRORS {
+                            tracing::error!("Max error threshold reached. Exiting loop.");
+                            break;
+                        }
+                    } else {
+                        error_count = 0_i32;
+                    }
+                }
+            })
+            .await;
+
+        tracing::warn!("Shutting down amplifier ingester...");
+    })
+}
+
+fn spawn_health_check_server(
+    port: u16,
+    config_path: PathBuf,
+    cancel_token: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::task::spawn(async move {
+        #[cfg(feature = "nats")]
+        let ingester = components::nats::new_amplifier_ingester(config_path)
+            .await
+            .expect("ingester is created");
+
+        #[cfg(feature = "gcp")]
+        let ingester = components::gcp::new_amplifier_ingester(config_path, cancel_token.clone())
+            .await
+            .expect("ingester is created");
+
+        let ingester = Arc::new(ingester);
+
+        tracing::debug!("Starting health check server...");
+
+        health_check::new(port)
+            .add_health_check(move || {
+                let ingester = Arc::clone(&ingester);
+                async move { ingester.check_health().await }
+            })
+            .run(cancel_token)
+            .await;
+
+        tracing::warn!("Shutting down health check server...");
+    })
+}

--- a/crates/amplifier-subscriber/Cargo.toml
+++ b/crates/amplifier-subscriber/Cargo.toml
@@ -13,6 +13,31 @@ supervisor.workspace = true
 tracing.workspace = true
 eyre.workspace = true
 infrastructure = { workspace = true, features = ["publisher-interfaces"] }
+tokio.workspace = true
+tokio-util.workspace = true
+serde.workspace = true
+clap.workspace = true
+ctrlc.workspace = true
+relayer-amplifier-api-integration.workspace = true
+toml.workspace = true
+url.workspace = true
+bin-util.workspace = true
+
+[features]
+default = ["gcp"]
+nats = [
+  "consumer-interfaces",
+  "publisher-interfaces",
+  "storage-interfaces",
+]
+gcp = [
+  "consumer-interfaces",
+  "publisher-interfaces",
+  "storage-interfaces",
+]
+consumer-interfaces = []
+publisher-interfaces = []
+storage-interfaces = []
 
 [lints]
 workspace = true

--- a/crates/amplifier-subscriber/src/components.rs
+++ b/crates/amplifier-subscriber/src/components.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "gcp")]
+pub(crate) mod gcp;
+#[cfg(feature = "nats")]
+pub(crate) mod nats;

--- a/crates/amplifier-subscriber/src/components/gcp.rs
+++ b/crates/amplifier-subscriber/src/components/gcp.rs
@@ -1,0 +1,97 @@
+use std::path::PathBuf;
+
+use crate::config::{self, Config, Validate};
+use eyre::{Context as _, ensure, eyre};
+use infrastructure::gcp;
+use infrastructure::gcp::publisher::PeekableGcpPublisher;
+use relayer_amplifier_api_integration::amplifier_api::{self, AmplifierApiClient};
+use serde::Deserialize;
+
+const TASK_KEY: &str = "last-task";
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub(crate) struct GcpSectionConfig {
+    pub gcp: GcpConfig,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub(crate) struct GcpConfig {
+    redis_connection: String,
+
+    tasks_topic: String,
+    tasks_subscription: String,
+
+    events_topic: String,
+    events_subscription: String,
+
+    nak_deadline_secs: i32,
+
+    message_buffer_size: usize,
+}
+
+impl Validate for GcpSectionConfig {
+    fn validate(&self) -> eyre::Result<()> {
+        ensure!(
+            !self.gcp.redis_connection.is_empty(),
+            eyre!("gcp redis_connection should be set")
+        );
+        ensure!(
+            !self.gcp.tasks_topic.is_empty(),
+            eyre!("gcp tasks_topic should be set")
+        );
+        ensure!(
+            !self.gcp.tasks_subscription.is_empty(),
+            eyre!("gcp tasks_subscription should be set")
+        );
+        ensure!(
+            !self.gcp.events_topic.is_empty(),
+            eyre!("gcp events_topic should be set")
+        );
+        ensure!(
+            !self.gcp.events_subscription.is_empty(),
+            eyre!("gcp events_subscription should be set")
+        );
+        ensure!(
+            self.gcp.nak_deadline_secs > 0_i32,
+            eyre!("gcp nak_deadline_secs should be positive set")
+        );
+        ensure!(
+            self.gcp.message_buffer_size > 0,
+            eyre!("gcp message_buffer_size should be set")
+        );
+        Ok(())
+    }
+}
+
+pub(crate) async fn new_amplifier_subscriber(
+    config_path: PathBuf,
+) -> eyre::Result<
+    amplifier_subscriber::Subscriber<PeekableGcpPublisher<amplifier_api::types::TaskItem>>,
+> {
+    let config = config::try_deserialize(&config_path).wrap_err("config file issues")?;
+    let queue_config: GcpSectionConfig =
+        config::try_deserialize(&config_path).wrap_err("gcp pubsub config issues")?;
+    let amplifier_client = amplifier_client(&config)?;
+
+    let task_queue_publisher = gcp::connectors::connect_peekable_publisher(
+        &queue_config.gcp.tasks_topic,
+        queue_config.gcp.redis_connection,
+        TASK_KEY.to_owned(),
+    )
+    .await
+    .wrap_err("task queue publisher connect err")?;
+
+    Ok(amplifier_subscriber::Subscriber::new(
+        amplifier_client,
+        task_queue_publisher,
+        config.amplifier_component.chain.clone(),
+    ))
+}
+
+fn amplifier_client(config: &Config) -> eyre::Result<AmplifierApiClient> {
+    AmplifierApiClient::new(
+        config.amplifier_component.url.clone(),
+        amplifier_api::TlsType::Certificate(Box::new(config.amplifier_component.identity.clone())),
+    )
+    .wrap_err("amplifier api client failed to create")
+}

--- a/crates/amplifier-subscriber/src/components/nats.rs
+++ b/crates/amplifier-subscriber/src/components/nats.rs
@@ -1,0 +1,77 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::config::{self, Validate, deserialize_duration_from_secs};
+use eyre::{Context, ensure, eyre};
+use infrastructure::nats::publisher::NatsPublisher;
+use infrastructure::nats::{self, StreamArgs};
+use relayer_amplifier_api_integration::amplifier_api::{self, AmplifierApiClient};
+use serde::Deserialize;
+use url::Url;
+
+use crate::Config;
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub(crate) struct NatsSectionConfig {
+    pub nats: NatsConfig,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub(crate) struct NatsConfig {
+    pub urls: Vec<Url>,
+    #[serde(rename = "connection_timeout_secs")]
+    #[serde(deserialize_with = "deserialize_duration_from_secs")]
+    pub connection_timeout: Duration,
+
+    pub stream_name: String,
+    pub stream_subject: String,
+    pub stream_description: String,
+}
+
+impl Validate for NatsSectionConfig {
+    fn validate(&self) -> eyre::Result<()> {
+        ensure!(
+            !self.nats.urls.is_empty(),
+            eyre!("nats urls should have at least one connection")
+        );
+
+        Ok(())
+    }
+}
+
+pub(crate) async fn new_amplifier_subscriber(
+    config_path: PathBuf,
+) -> eyre::Result<amplifier_subscriber::Subscriber<NatsPublisher<amplifier_api::types::TaskItem>>> {
+    let config = config::try_deserialize(&config_path).wrap_err("config file issues")?;
+    let nats_config: NatsSectionConfig =
+        config::try_deserialize(&config_path).wrap_err("nats config issues")?;
+    let amplifier_client = amplifier_client(&config)?;
+
+    let stream = StreamArgs {
+        name: nats_config.nats.stream_name.to_owned(),
+        subject: nats_config.nats.stream_subject.to_owned(),
+        description: nats_config.nats.stream_description.to_owned(),
+    };
+
+    let task_queue_publisher = nats::connectors::connect_publisher(
+        &nats_config.nats.urls,
+        stream,
+        nats_config.nats.stream_subject,
+    )
+    .await
+    .wrap_err("task queue publisher connect err")?;
+
+    Ok(amplifier_subscriber::Subscriber::new(
+        amplifier_client,
+        task_queue_publisher,
+        config.amplifier_component.chain.clone(),
+    ))
+}
+
+fn amplifier_client(config: &Config) -> eyre::Result<AmplifierApiClient> {
+    AmplifierApiClient::new(
+        config.amplifier_component.url.clone(),
+        amplifier_api::TlsType::Certificate(Box::new(config.amplifier_component.identity.clone())),
+    )
+    .wrap_err("amplifier api client failed to create")
+}

--- a/crates/amplifier-subscriber/src/config.rs
+++ b/crates/amplifier-subscriber/src/config.rs
@@ -1,0 +1,68 @@
+use core::time::Duration;
+use std::path::Path;
+
+use eyre::{WrapErr as _, ensure, eyre};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Deserializer};
+
+pub(crate) trait Validate {
+    fn validate(&self) -> eyre::Result<()>;
+}
+
+/// Top-level configuration for the relayer.
+#[derive(Debug, Deserialize, PartialEq)]
+pub(crate) struct Config {
+    /// Configuration for the Amplifier API processor
+    pub amplifier_component: relayer_amplifier_api_integration::Config,
+    pub concurrent_queue_items: usize,
+    /// Duration (in seconds) to wait between consecutive polling
+    /// operations Used to prevent overwhelming the network with requests
+    #[serde(rename = "tickrate_secs")]
+    #[serde(deserialize_with = "deserialize_duration_from_secs")]
+    pub tickrate: Duration,
+
+    /// Configuration for health check server
+    #[serde(rename = "health_check_server")]
+    pub health_check: HealthCheckConfig,
+}
+
+/// Configuration for health check server
+#[derive(Debug, Deserialize, PartialEq)]
+pub(crate) struct HealthCheckConfig {
+    /// Port for the health check server
+    #[serde(rename = "port")]
+    pub port: u16,
+}
+
+impl Validate for Config {
+    fn validate(&self) -> eyre::Result<()> {
+        ensure!(
+            !self.amplifier_component.chain.trim().is_empty(),
+            "chain could not be empty",
+        );
+
+        Ok(())
+    }
+}
+
+pub(crate) fn try_deserialize<T: DeserializeOwned + Validate>(
+    config_path: &Path,
+) -> eyre::Result<T> {
+    ensure!(
+        config_path.exists() && config_path.is_file(),
+        eyre!("Path should be a file and exist {:?}", config_path)
+    );
+    let config_file = std::fs::read_to_string(config_path).wrap_err("cannot read config file")?;
+
+    let config = toml::from_str::<T>(&config_file).wrap_err("invalid config file content")?;
+    config.validate()?;
+    Ok(config)
+}
+
+pub(crate) fn deserialize_duration_from_secs<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let seconds = u64::deserialize(deserializer)?;
+    Ok(Duration::from_secs(seconds))
+}

--- a/crates/amplifier-subscriber/src/main.rs
+++ b/crates/amplifier-subscriber/src/main.rs
@@ -37,7 +37,7 @@ use config::Config;
 use tokio_util::sync::CancellationToken;
 
 // TODO: Move this to config
-const MAX_ERRORS: i32 = 5;
+const MAX_ERRORS: i32 = 20;
 
 #[derive(Parser, Debug)]
 #[command(author = "Eiger", name = "Axelar<>Blockchain Relayer")]

--- a/crates/amplifier-subscriber/src/main.rs
+++ b/crates/amplifier-subscriber/src/main.rs
@@ -1,0 +1,179 @@
+//! # Amplifier Subscriber
+//!
+//! The Amplifier Subscriber service connects to the Axelar Amplifier network
+//! and subscribes to events that need to be relayed.
+//!
+//! This binary provides:
+//! - A configurable event subscriber with different backend implementations (NATS, GCP)
+//! - Health check endpoints for monitoring service health
+//! - Graceful shutdown handling with signal trapping
+//!
+//! The service will periodically poll for events based on the configured tickrate
+//! and process them according to the configured backend (NATS or GCP Pub/Sub).
+//!
+//! ## Usage
+//!
+//! ```bash
+//! amplifier-subscriber --config path/to/config.toml
+//! ```
+//!
+//! ## Configuration
+//!
+//! The service is configured via a TOML file that specifies:
+//! - Health check server port
+//! - Event processing tickrate
+//! - Backend-specific configuration (NATS or GCP)
+//!
+mod components;
+mod config;
+
+use core::time::Duration;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use bin_util::health_check;
+use clap::Parser;
+use config::Config;
+use tokio_util::sync::CancellationToken;
+
+// TODO: Move this to config
+const MAX_ERRORS: i32 = 5;
+
+#[derive(Parser, Debug)]
+#[command(author = "Eiger", name = "Axelar<>Blockchain Relayer")]
+pub(crate) struct Cli {
+    #[arg(
+        long,
+        short,
+        default_value = "relayer-config.toml",
+        help = "Config path"
+    )]
+    pub config_path: PathBuf,
+}
+
+#[tokio::main]
+async fn main() {
+    #[cfg(debug_assertions)]
+    {
+        // Safety: Setting an environment variable is safe in this context because it only affects the current process.
+        unsafe {
+            std::env::set_var("RUST_BACKTRACE", "full");
+        }
+    }
+    let cli = Cli::parse();
+
+    let config: Config = config::try_deserialize(&cli.config_path).expect("generic config");
+    let cancel_token = setup_shutdown_signal();
+
+    tokio::try_join!(
+        spawn_subscriber_worker(
+            config.tickrate,
+            cli.config_path.clone(),
+            cancel_token.clone()
+        ),
+        spawn_health_check_server(
+            config.health_check.port,
+            cli.config_path.clone(),
+            cancel_token.clone()
+        )
+    )
+    .expect("Failed to join tasks");
+
+    tracing::info!("Amplifier subscriber has been shut down");
+}
+
+fn setup_shutdown_signal() -> CancellationToken {
+    let token = CancellationToken::new();
+    let token_clone = token.clone();
+
+    ctrlc::set_handler(move || {
+        if token_clone.is_cancelled() {
+            tracing::warn!("Immediate shutdown initiated.");
+            #[expect(clippy::restriction, reason = "immediate exit")]
+            std::process::exit(1);
+        } else {
+            tracing::info!("Graceful shutdown initiated. Press Ctrl+C again for immediate exit.");
+            token_clone.cancel();
+        }
+    })
+    .expect("Failed to register ctrl+c handler");
+
+    token
+}
+
+fn spawn_subscriber_worker(
+    tickrate: Duration,
+    config_path: PathBuf,
+    cancel_token: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    // Avoid shadowing by renaming the variable
+    let shutdown_token = cancel_token;
+    tokio::task::spawn(async move {
+        #[cfg(feature = "nats")]
+        let mut subscriber = components::nats::new_amplifier_subscriber(config_path)
+            .await
+            .expect("subscriber is created");
+
+        #[cfg(feature = "gcp")]
+        let mut subscriber = components::gcp::new_amplifier_subscriber(config_path)
+            .await
+            .expect("subscriber is created");
+
+        tracing::debug!("Starting amplifier subscriber...");
+
+        let mut error_count: i32 = 0;
+
+        shutdown_token
+            .run_until_cancelled(async move {
+                let mut work_interval = tokio::time::interval(tickrate);
+                loop {
+                    work_interval.tick().await;
+                    if let Err(err) = subscriber.subscribe().await {
+                        tracing::error!(?err, "error during ingest, skipping...");
+                        error_count = error_count.saturating_add(1);
+                        if error_count >= MAX_ERRORS {
+                            tracing::error!("Max error threshold reached. Exiting loop.");
+                            break;
+                        }
+                    } else {
+                        error_count = 0_i32;
+                    }
+                }
+            })
+            .await;
+
+        tracing::warn!("Shutting down amplifier subscriber...");
+    })
+}
+
+fn spawn_health_check_server(
+    port: u16,
+    config_path: PathBuf,
+    cancel_token: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::task::spawn(async move {
+        #[cfg(feature = "nats")]
+        let subscriber = components::nats::new_amplifier_subscriber(config_path)
+            .await
+            .expect("subscriber is created");
+
+        #[cfg(feature = "gcp")]
+        let subscriber = components::gcp::new_amplifier_subscriber(config_path)
+            .await
+            .expect("subscriber is created");
+
+        let subscriber = Arc::new(subscriber);
+
+        tracing::debug!("Starting health check server...");
+
+        health_check::new(port)
+            .add_health_check(move || {
+                let subscriber = Arc::clone(&subscriber);
+                async move { subscriber.check_health().await }
+            })
+            .run(cancel_token)
+            .await;
+
+        tracing::warn!("Shutting down health check server...");
+    })
+}

--- a/crates/bin-util/Cargo.toml
+++ b/crates/bin-util/Cargo.toml
@@ -9,7 +9,14 @@ edition.workspace = true
 
 [dependencies]
 ctrlc.workspace = true
+tokio.workspace = true
 tokio-util.workspace = true
+tracing.workspace = true
+axum.workspace = true
+eyre.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+futures.workspace = true
 
 [lints]
 workspace = true

--- a/crates/bin-util/src/health_check.rs
+++ b/crates/bin-util/src/health_check.rs
@@ -1,0 +1,369 @@
+//! # Health Check
+//!
+//! A lightweight HTTP server for implementing health and readiness probes.
+//!
+//! This crate provides functionality to create an HTTP server that responds to
+//! health check requests on `/healthz` and readiness check requests on `/readyz`.
+//! It allows registration of custom health check functions that determine the
+//! server's health status.
+//!
+//! ## Example
+//!
+//! ```rust
+//! use health_check::Server;
+//! use tokio_util::sync::CancellationToken;
+//! use eyre::Result;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<()> {
+//!     let cancel_token = CancellationToken::new();
+//!     let token_clone = cancel_token.clone();
+//!
+//!     let server = Server::new(8080)
+//!         .add_health_check(|| async { Ok(()) });
+//!
+//!     // Run the server in a separate tokio task
+//!     tokio::spawn(async move {
+//!         server.run(token_clone).await;
+//!     });
+//!
+//!     // Your application logic here
+//!     // When ready to shut down:
+//!     cancel_token.cancel();
+//!
+//!     Ok(())
+//! }
+//! ```
+use axum::{
+    Router,
+    extract::Extension,
+    http::StatusCode,
+    response::{IntoResponse, Json},
+    routing::get,
+};
+use core::future::Future;
+use core::pin::Pin;
+use eyre::Result;
+use serde_json::json;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+/// A type alias representing a health check function.
+///
+/// This type encapsulates an async function that returns a `Result<()>`,
+/// where `Ok(())` indicates a successful health check and `Err(_)` indicates a failure.
+pub type HealthCheck =
+    Box<dyn Fn() -> Pin<Box<dyn Future<Output = Result<()>> + Send>> + Send + Sync>;
+
+/// A server that handles health check and readiness probe requests.
+///
+/// The server responds to HTTP requests on two endpoints:
+/// - `/healthz`: For health checks (liveness probes)
+/// - `/readyz`: For readiness probes
+///
+/// Both endpoints return 200 OK when all registered health checks pass,
+/// or 503 Service Unavailable when any check fails.
+pub struct Server {
+    port: u16,
+    health_checks: Vec<HealthCheck>,
+}
+
+/// Creates a new `Server` bound to the specified port.
+///
+/// # Arguments
+///
+/// * `port` - The TCP port on which the server will listen for HTTP requests
+///
+/// # Returns
+///
+/// A new `Server` instance with no health checks registered.
+#[must_use]
+pub fn new(port: u16) -> Server {
+    Server {
+        port,
+        health_checks: Vec::new(),
+    }
+}
+
+impl Server {
+    /// Creates a new `Server` bound to the specified port.
+    ///
+    /// # Arguments
+    ///
+    /// * `port` - The TCP port on which the server will listen for HTTP requests
+    ///
+    /// # Returns
+    ///
+    /// A new `Server` instance with no health checks registered.
+    #[must_use]
+    pub fn new(port: u16) -> Self {
+        Self {
+            port,
+            health_checks: Vec::new(),
+        }
+    }
+
+    /// Registers a health check function with the server.
+    ///
+    /// Multiple health checks can be registered by chaining this method.
+    /// All health checks are executed in parallel when a health check request is received.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A function that returns a future resolving to a `Result<()>`.
+    ///   An `Ok(())` result indicates the health check passed, while
+    ///   an `Err(_)` indicates it failed.
+    ///
+    /// # Returns
+    ///
+    /// `Self` with the health check added, allowing for method chaining.
+    #[must_use]
+    pub fn add_health_check<F, Fut>(mut self, f: F) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<()>> + Send + 'static,
+    {
+        self.health_checks.push(Box::new(move || Box::pin(f())));
+        self
+    }
+
+    /// Starts the HTTP server and runs until the cancellation token is triggered.
+    ///
+    /// The server will bind to `0.0.0.0` on the configured port and respond to
+    /// health check and readiness requests. When the cancellation token is triggered,
+    /// the server will perform a graceful shutdown.
+    ///
+    /// # Arguments
+    ///
+    /// * `cancel_token` - A cancellation token that will trigger server shutdown when canceled
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if it fails to bind to the specified port. This can happen
+    /// if the port is already in use or if the process doesn't have permission to bind to
+    /// the requested port.
+    pub async fn run(self, cancel_token: CancellationToken) {
+        let health_checks: Arc<[HealthCheck]> = Arc::from(self.health_checks.into_boxed_slice());
+        let state = Arc::clone(&health_checks);
+
+        let app = Router::new()
+            .route("/healthz", get(handle_healthz))
+            .route("/readyz", get(handle_readyz))
+            .layer(Extension(state));
+
+        let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", self.port))
+            .await
+            .expect("Failed to bind to address");
+
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                cancel_token.cancelled().await;
+            })
+            .await
+            .expect("Server error");
+    }
+}
+
+async fn handle_healthz(
+    Extension(health_checks): Extension<Arc<[HealthCheck]>>,
+) -> impl IntoResponse {
+    check_and_respond(
+        &health_checks,
+        StatusCode::OK,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "HEALTHY",
+        "UNHEALTHY",
+    )
+    .await
+}
+
+async fn handle_readyz(
+    Extension(health_checks): Extension<Arc<[HealthCheck]>>,
+) -> impl IntoResponse {
+    check_and_respond(
+        &health_checks,
+        StatusCode::OK,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "READY",
+        "UNREADY",
+    )
+    .await
+}
+
+async fn check_and_respond(
+    health_checks: &[HealthCheck],
+    ok_status: StatusCode,
+    err_status: StatusCode,
+    ok_str: &str,
+    err_str: &str,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if health_checks.is_empty() {
+        return (ok_status, Json(json!({ "status": ok_str })));
+    }
+
+    // Run all health checks in parallel
+    let results = futures::future::join_all(health_checks.iter().map(|check| check())).await;
+
+    let has_error = results.iter().any(core::result::Result::is_err);
+    if has_error {
+        tracing::debug!("Health check failed");
+        (err_status, Json(json!({ "status": err_str })))
+    } else {
+        tracing::debug!("Health check succeeded");
+        (ok_status, Json(json!({ "status": ok_str })))
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::{
+        sync::atomic::{AtomicBool, Ordering},
+        time::Duration,
+    };
+    use tokio::time::sleep;
+
+    async fn run_server<F, Fut>(port: u16, health_check: F) -> CancellationToken
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<()>> + Send + 'static,
+    {
+        let cancel_token = CancellationToken::new();
+        let token_clone = cancel_token.clone();
+
+        let server = Server::new(port).add_health_check(health_check);
+        tokio::spawn(async move {
+            server.run(token_clone).await;
+        });
+
+        // Give the server time to start
+        sleep(Duration::from_millis(100)).await;
+
+        cancel_token
+    }
+
+    fn get_free_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    #[tokio::test]
+    async fn test_health_check_success() {
+        let port = get_free_port();
+        run_server(port, || async { Ok(()) }).await;
+
+        let url = format!("http://127.0.0.1:{port}/healthz");
+        let resp = reqwest::get(&url).await.unwrap();
+        assert_eq!(resp.status(), 200);
+        assert_eq!(resp.text().await.unwrap(), r#"{"status":"HEALTHY"}"#);
+    }
+
+    #[tokio::test]
+    async fn test_health_check_failure() {
+        let port = get_free_port();
+        run_server(port, || async { Err(eyre::eyre!("Health check failed")) }).await;
+
+        let url = format!("http://127.0.0.1:{port}/healthz");
+        let resp = reqwest::get(&url).await.unwrap();
+        assert_eq!(resp.status(), 503);
+        assert_eq!(resp.text().await.unwrap(), r#"{"status":"UNHEALTHY"}"#);
+    }
+
+    #[tokio::test]
+    async fn test_multiple_health_checks() {
+        let port = get_free_port();
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag2 = flag.clone();
+        let cancel_token = CancellationToken::new();
+        let token_clone = cancel_token.clone();
+
+        let server = Server::new(port)
+            .add_health_check(|| async { Ok(()) })
+            .add_health_check(move || {
+                let ok = !flag2.load(Ordering::SeqCst);
+                async move {
+                    if ok {
+                        Ok(())
+                    } else {
+                        Err(eyre::eyre!("Intentional failure"))
+                    }
+                }
+            });
+
+        tokio::spawn(async move {
+            server.run(token_clone).await;
+        });
+
+        sleep(Duration::from_millis(100)).await;
+
+        let url = format!("http://127.0.0.1:{port}/healthz");
+        let resp = reqwest::get(&url).await.unwrap();
+        assert_eq!(resp.status(), 200);
+        assert_eq!(resp.text().await.unwrap(), r#"{"status":"HEALTHY"}"#);
+
+        flag.store(true, Ordering::SeqCst);
+        let resp = reqwest::get(&url).await.unwrap();
+        assert_eq!(resp.status(), 503);
+        assert_eq!(resp.text().await.unwrap(), r#"{"status":"UNHEALTHY"}"#);
+    }
+
+    #[tokio::test]
+    async fn test_readyz_endpoint() {
+        let port = get_free_port();
+        let cancel_token = run_server(port, || async { Ok(()) }).await;
+
+        let url = format!("http://127.0.0.1:{port}/readyz");
+        let resp = reqwest::get(&url).await.unwrap();
+        assert_eq!(resp.status(), 200);
+        assert_eq!(resp.text().await.unwrap(), r#"{"status":"READY"}"#);
+
+        cancel_token.cancel();
+
+        let port2 = get_free_port();
+        let cancel_token2 =
+            run_server(port2, || async { Err(eyre::eyre!("Readiness failed")) }).await;
+
+        let url2 = format!("http://127.0.0.1:{port2}/readyz");
+        let resp2 = reqwest::get(&url2).await.unwrap();
+        assert_eq!(resp2.status(), 503);
+        assert_eq!(resp2.text().await.unwrap(), r#"{"status":"UNREADY"}"#);
+
+        cancel_token2.cancel();
+    }
+
+    #[tokio::test]
+    async fn test_not_found() {
+        let port = get_free_port();
+        let cancel_token = run_server(port, || async { Ok(()) }).await;
+
+        let url = format!("http://127.0.0.1:{port}/notfound");
+        let resp = reqwest::get(&url).await.unwrap();
+        assert_eq!(resp.status(), 404);
+
+        cancel_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn test_cancellation() {
+        let port = get_free_port();
+        let cancel_token = run_server(port, || async { Ok(()) }).await;
+
+        // Verify server is running
+        let url = format!("http://127.0.0.1:{port}/healthz");
+        let resp = reqwest::get(&url).await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        // Cancel the server
+        cancel_token.cancel();
+        sleep(Duration::from_millis(100)).await;
+
+        // After cancellation, the server should no longer respond
+        let result = reqwest::get(&url).await;
+        assert!(
+            result.is_err(),
+            "Server should no longer respond after cancellation"
+        );
+    }
+}

--- a/crates/bin-util/src/lib.rs
+++ b/crates/bin-util/src/lib.rs
@@ -1,4 +1,6 @@
 //! Binary utils
+
+pub mod health_check;
 use tokio_util::sync::CancellationToken;
 
 /// Ensures backtrace is enabled

--- a/crates/infrastructure/src/gcp.rs
+++ b/crates/infrastructure/src/gcp.rs
@@ -48,6 +48,8 @@ pub enum GcpError {
     Serialize(std::io::Error),
     #[error("error connecting to redis {0}")]
     Connection(RedisError),
+    #[error("redis operation failed {0}")]
+    Redis(RedisError),
     #[error("error serializing data `{value}` to redis {err}")]
     RedisSerialize { value: String, err: std::io::Error },
     #[error("error saving data to redis {0}")]

--- a/crates/infrastructure/src/gcp/kv_store.rs
+++ b/crates/infrastructure/src/gcp/kv_store.rs
@@ -38,6 +38,14 @@ where
         })
     }
 
+    /// Ping the Redis server to check connectivity
+    /// # Errors
+    ///  on connection issues
+    pub async fn ping(&self) -> Result<(), redis::RedisError> {
+        let mut connection = self.connection.clone();
+        redis::cmd("PING").query_async(&mut connection).await
+    }
+
     pub(crate) async fn upsert(&self, value: &T) -> Result<(), GcpError> {
         let bytes = borsh::to_vec(value).map_err(|err| GcpError::RedisSerialize {
             value: value.to_string(),

--- a/crates/infrastructure/src/gcp/publisher.rs
+++ b/crates/infrastructure/src/gcp/publisher.rs
@@ -47,7 +47,7 @@ impl<T> GcpPublisher<T> {
 
 impl<T> interfaces::publisher::Publisher<T> for GcpPublisher<T>
 where
-    T: BorshSerialize + Debug,
+    T: BorshSerialize + Debug + Send + Sync,
 {
     type Return = String;
 
@@ -75,6 +75,35 @@ where
             .await
             .map_err(|err| GcpError::Publish(Box::new(err)))?;
         Ok(result)
+    }
+
+    #[allow(refining_impl_trait, reason = "simplification")]
+    async fn check_health(&self) -> Result<(), GcpError> {
+        tracing::debug!("checking health for GCP publisher");
+
+        // Create a small health check message
+        let health_attributes = HashMap::from([("health_check".to_owned(), "true".to_owned())]);
+
+        let health_message = PubsubMessage {
+            data: Vec::from("health_check"),
+            attributes: health_attributes,
+            ..Default::default()
+        };
+
+        // Try to publish the message and await the result
+        let awaiter = self.publisher.publish(health_message).await;
+
+        // Check if we can get a result from the awaiter
+        match awaiter.get().await {
+            Ok(_) => {
+                tracing::debug!("GCP publisher health check successful");
+                Ok(())
+            }
+            Err(err) => {
+                tracing::error!("GCP publisher health check failed: {}", err);
+                Err(GcpError::Publish(Box::new(err)))
+            }
+        }
     }
 }
 
@@ -106,8 +135,8 @@ where
 
 impl<T> interfaces::publisher::Publisher<T> for PeekableGcpPublisher<T>
 where
-    T: QueueMsgId + BorshSerialize + Debug + Clone,
-    T::MessageId: BorshSerialize + BorshDeserialize + Debug + Display,
+    T: QueueMsgId + BorshSerialize + Debug + Clone + Send + Sync,
+    T::MessageId: BorshSerialize + BorshDeserialize + Debug + Display + Send + Sync,
 {
     type Return = String;
     #[allow(refining_impl_trait, reason = "simplification")]
@@ -120,6 +149,26 @@ where
         let res = self.publisher.publish(deduplication_id, data).await?;
         self.last_message_id_store.upsert(&data.id()).await?;
         Ok(res)
+    }
+
+    #[allow(refining_impl_trait, reason = "simplification")]
+    async fn check_health(&self) -> Result<(), GcpError> {
+        tracing::debug!("checking health for PeekableGcpPublisher");
+
+        // Check the GCP publisher health first
+        self.publisher.check_health().await?;
+
+        // Check Redis client health by performing a simple operation
+        match self.last_message_id_store.ping().await {
+            Ok(()) => {
+                tracing::debug!("Redis client health check successful");
+                Ok(())
+            }
+            Err(err) => {
+                tracing::error!("Redis client health check failed: {}", err);
+                Err(GcpError::Redis(err))
+            }
+        }
     }
 }
 

--- a/crates/infrastructure/src/interfaces.rs
+++ b/crates/infrastructure/src/interfaces.rs
@@ -12,7 +12,7 @@ pub mod consumer {
         fn ack(
             &self,
             ack_kind: AckKind,
-        ) -> impl Future<Output = Result<(), impl Error + Send + Sync + 'static>>;
+        ) -> impl Future<Output = Result<(), impl Error + Send + Sync + 'static>> + Send;
     }
 
     /// consumer
@@ -28,6 +28,19 @@ pub mod consumer {
                 impl Error + Send + Sync + 'static,
             >,
         >;
+
+        /// Checks the health status of the consumer connection.
+        ///
+        /// This method verifies the consumer's ability to connect to the underlying service
+        /// and returns an error if the health check fails.
+        ///
+        /// # Returns
+        ///
+        /// * `Ok(())` - If the consumer is healthy and can connect to the service
+        /// * `Err(...)` - If there are any issues with the consumer's health or connectivity
+        fn check_health(
+            &self,
+        ) -> impl Future<Output = Result<(), impl Error + Send + Sync + 'static>> + Send;
     }
 
     /// Ack responses
@@ -78,6 +91,19 @@ pub mod publisher {
             deduplication_id: impl Into<String>,
             data: &T,
         ) -> impl Future<Output = Result<Self::Return, impl Error + Send + Sync + 'static>>;
+
+        /// Checks the health status of the publisher connection.
+        ///
+        /// This method verifies the publisher's ability to connect to the underlying service
+        /// and returns an error if the health check fails.
+        ///
+        /// # Returns
+        ///
+        /// * `Ok(())` - If the publisher is healthy and can connect to the service
+        /// * `Err(...)` - If there are any issues with the publisher's health or connectivity
+        fn check_health(
+            &self,
+        ) -> impl Future<Output = Result<(), impl Error + Send + Sync + 'static>> + Send;
     }
 }
 

--- a/crates/infrastructure/src/nats/publisher.rs
+++ b/crates/infrastructure/src/nats/publisher.rs
@@ -35,7 +35,9 @@ impl<T> NatsPublisher<T> {
     }
 }
 
-impl<T: BorshSerialize + Debug> interfaces::publisher::Publisher<T> for NatsPublisher<T> {
+impl<T: BorshSerialize + Debug + Send + Sync> interfaces::publisher::Publisher<T>
+    for NatsPublisher<T>
+{
     type Return = PublishAck;
 
     #[allow(refining_impl_trait, reason = "simplify")]
@@ -61,6 +63,13 @@ impl<T: BorshSerialize + Debug> interfaces::publisher::Publisher<T> for NatsPubl
         tracing::debug!("message published");
 
         Ok(publish_ack)
+    }
+
+    #[allow(refining_impl_trait, reason = "simplification")]
+    async fn check_health(&self) -> Result<(), NatsError> {
+        tracing::debug!("checking health");
+        self.stream.get_info().await?;
+        Ok(())
     }
 }
 

--- a/relayer-config-example.toml
+++ b/relayer-config-example.toml
@@ -1,0 +1,40 @@
+tickrate_secs = 5
+concurrent_queue_items = 50
+
+[nats]
+urls = ["nats://localhost:4222"]
+connection_timeout_secs = 30
+
+stream_name = "events"
+stream_subject = "events.>"
+stream_description = "Stream for all system events"
+
+consumer_description = "Event processor"
+deliver_group = "event-processors"
+
+[gcp]
+redis_connection = "redis://127.0.0.1/"
+tasks_topic = "amplifier-tasks"
+tasks_subscription = "amplifier-tasks-sub"
+events_topic = "amplifier-events"
+events_subscription = "amplifier-events-sub"
+nak_deadline_secs = 10
+message_buffer_size = 1000
+
+[amplifier_component]
+# pem format cert
+identity = '''
+-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE-----
+-----BEGIN PRIVATE KEY-----
+...
+-----END PRIVATE KEY-----
+'''
+url = "https://amplifier-devnet-amplifier.devnet.axelar.dev/"
+chain = "starknet-devnet-v1"
+get_chains_limit = 100
+invalid_healthchecks_before_shutdown = 100
+
+[health_check_server]
+port = 8080


### PR DESCRIPTION
**Describe the changes**

This PR enhances the amplifier components (ingester and subscriber) into standalone executable services with integrated health monitoring endpoints. This change allows for greater deployment flexibility, better isolation between components, and improved system reliability.

Key Changes:
* Created separate binary entrypoints for amplifier-ingester and amplifier-subscriber
* Added HTTP health check endpoints to monitor service status
* Enhanced infrastructure interfaces to better support both NATS and GCP Pub/Sub backends
* Updated documentation with architecture details and configuration examples

**Checklist**

- [x] Tests have been added/updated for the changes.
- [x] Documentation has been updated for the changes (if applicable).
- [x] The code follows Rust's style guidelines.

**Additional Context**
Add any other context about the pull request here.
