### PR TITLE
Add terraform implementation variable name

### DIFF
--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -1,20 +1,20 @@
 resource "google_service_account" "tasks_publisher_iam" {
-  account_id   = "tasks-publisher-${var.axelar_implementation}"
+  account_id   = "tasks-pub-${var.axelar_implementation}"
   display_name = "Service account for tasks publisher"
 }
 
 resource "google_service_account" "tasks_subscriber_iam" {
-  account_id   = "tasks-subscriber-${var.axelar_implementation}"
+  account_id   = "tasks-sub-${var.axelar_implementation}"
   display_name = "Service account for tasks subscriber"
 }
 
 resource "google_service_account" "events_publisher_iam" {
-  account_id   = "events-publisher-${var.axelar_implementation}"
+  account_id   = "events-pub-${var.axelar_implementation}"
   display_name = "Service account for events publisher"
 }
 
 resource "google_service_account" "events_subscriber_iam" {
-  account_id   = "events-subscriber-${var.axelar_implementation}"
+  account_id   = "events-sub-${var.axelar_implementation}"
   display_name = "Service account for tasks subscriber"
 }
 

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -1,20 +1,20 @@
 resource "google_service_account" "tasks_publisher_iam" {
-  account_id   = "tasks-publisher"
+  account_id   = "tasks-publisher-${var.axelar_implementation}"
   display_name = "Service account for tasks publisher"
 }
 
 resource "google_service_account" "tasks_subscriber_iam" {
-  account_id   = "tasks-subscriber"
+  account_id   = "tasks-subscriber-${var.axelar_implementation}"
   display_name = "Service account for tasks subscriber"
 }
 
 resource "google_service_account" "events_publisher_iam" {
-  account_id   = "events-publisher"
+  account_id   = "events-publisher-${var.axelar_implementation}"
   display_name = "Service account for events publisher"
 }
 
 resource "google_service_account" "events_subscriber_iam" {
-  account_id   = "events-subscriber"
+  account_id   = "events-subscriber-${var.axelar_implementation}"
   display_name = "Service account for tasks subscriber"
 }
 

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -1,0 +1,4 @@
+variable "axelar_implementation" {
+  type        = string
+  description = "Name of axelar project/specific implementation that will be appended to account names"
+}

--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -1,5 +1,5 @@
 resource "google_kms_key_ring" "amplifier_api" {
-  name     = "amplifier_api_keyring"
+  name     = "${var.axelar_implementation}_keyring"
   location = "global"
 }
 

--- a/terraform/modules/kms/variables.tf
+++ b/terraform/modules/kms/variables.tf
@@ -1,3 +1,8 @@
+variable "axelar_implementation" {
+  type        = string
+  description = "Name of axelar project/specific implementation that will be appended to account names"
+}
+
 variable "protection_level" {
   type        = string
   description = "Protection level of signing key"

--- a/terraform/modules/pubsub/main.tf
+++ b/terraform/modules/pubsub/main.tf
@@ -1,10 +1,10 @@
 locals {
-  amplifier_events_topic     = "amplifier-events"
-  amplifier_events_sub       = "amplifier-events-sub"
-  amplifier_events_dlq_topic = "amplifier-events-dlq"
-  amplifier_tasks_topic      = "amplifier-tasks"
-  amplifier_tasks_sub        = "amplifier-tasks-sub"
-  amplifier_tasks_dlq_topic  = "amplifier-tasks-dlq"
+  amplifier_events_topic     = "${var.axelar_implementation}-amplifier-events"
+  amplifier_events_sub       = "${var.axelar_implementation}-amplifier-events-sub"
+  amplifier_events_dlq_topic = "${var.axelar_implementation}-amplifier-events-dlq"
+  amplifier_tasks_topic      = "${var.axelar_implementation}-amplifier-tasks"
+  amplifier_tasks_sub        = "${var.axelar_implementation}-amplifier-tasks-sub"
+  amplifier_tasks_dlq_topic  = "${var.axelar_implementation}-amplifier-tasks-dlq"
 }
 
 resource "google_pubsub_topic" "amplifier_events" {

--- a/terraform/modules/pubsub/variables.tf
+++ b/terraform/modules/pubsub/variables.tf
@@ -1,3 +1,8 @@
+variable "axelar_implementation" {
+  type        = string
+  description = "Name of axelar project/specific implementation that will be appended to account names"
+}
+
 variable "ack_deadline_seconds" {
   description = "The maximum time after a subscriber receives a message before the subscriber should acknowledge the message"
   type        = number


### PR DESCRIPTION
Newly added variables in resource names will make it possible that resources on GCP do not clash when deploying multiple environments