### PR TITLE
feat(supervisor): set MissedTickBehavior::Delay for shutdown and work…

### DIFF
--- a/crates/supervisor/src/lib.rs
+++ b/crates/supervisor/src/lib.rs
@@ -102,6 +102,7 @@ pub fn run(
                 tracing::info!("all workers are running");
 
                 let mut interval = tokio::time::interval(Duration::from_millis(SHUTDOWN_SIGNAL_CHECK_INTERVAL_MS));
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
                 loop {
                     tokio::select! {
                         _ = interval.tick() => {
@@ -213,6 +214,8 @@ fn spawn_worker<'scope>(
                 cancel_token
                     .run_until_cancelled(async {
                         let mut interval = tokio::time::interval(tickrate);
+                        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
                         let result: Result<(), _> = loop {
                             interval.tick().await;
                             if let Err(err) = worker.do_work().await {


### PR DESCRIPTION
Set `tokio::time::MissedTickBehavior::Delay` so if a tick is missed, it is skipped and the next tick occurs after the specified delay.
